### PR TITLE
Make image rootfs smaller

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -43,4 +43,4 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: vanilla-pico-rootfs
-        path: rootfs/vanilla-pico.tar.gz
+        path: rootfs/vanilla-pico.tar.zst

--- a/recipe.yml
+++ b/recipe.yml
@@ -5,5 +5,5 @@ singlelayer: true
 labels:
   maintainer: Vanilla OS Contributors
 adds:
-  rootfs/vanilla-pico.tar.gz: /
+  rootfs/vanilla-pico.tar.zst: /
 cmd: "/bin/bash"

--- a/rootfs/build.sh
+++ b/rootfs/build.sh
@@ -14,7 +14,8 @@ CLEANUP_DIRS="/usr/share/doc/*
 /usr/share/doc/kde/HTML/*/*
 /usr/share/gnome/help/*/*
 /usr/share/locale/*
-/usr/share/omf/*/*-*.emf"
+/usr/share/omf/*/*-*.emf
+/var/cache"
 
 # Root check - debootstrap requires root privileges
 if [ "$(id -u)" != "0" ];
@@ -64,5 +65,8 @@ for dir in $CLEANUP_DIRS; do
 done
 
 # Compression
-tar -czf $ROOTFS_NAME.tar.gz -C $ROOTFS_NAME .
-chmod 644 $ROOTFS_NAME.tar.gz
+tar -czf $ROOTFS_NAME.tar -C $ROOTFS_NAME .
+zstd -19 $ROOTFS_NAME.tar
+rm $ROOTFS_NAME.tar
+chmod 644 $ROOTFS_NAME.tar.zst
+

--- a/rootfs/build.sh
+++ b/rootfs/build.sh
@@ -65,7 +65,7 @@ for dir in $CLEANUP_DIRS; do
 done
 
 # Compression
-tar -czf $ROOTFS_NAME.tar -C $ROOTFS_NAME .
+tar -cvf $ROOTFS_NAME.tar -C $ROOTFS_NAME .
 zstd -19 $ROOTFS_NAME.tar
 rm $ROOTFS_NAME.tar
 chmod 644 $ROOTFS_NAME.tar.zst


### PR DESCRIPTION
Decreases the size of the rootfs image to ~62MB (previously ~90MB)

Changes:
- add `/var/cache` to the directories that get deleted
- use zstd compression instead of gzip