### PR TITLE
fix: Cleanup

### DIFF
--- a/rootfs/build.sh
+++ b/rootfs/build.sh
@@ -16,8 +16,8 @@ CLEANUP_DIRS="/usr/share/doc/*
 /usr/share/locale/*
 /usr/share/omf/*/*-*.emf
 /var/cache
-/var/log
-/tmp"
+/var/log/*
+/tmp/*"
 
 # Root check - debootstrap requires root privileges
 if [ "$(id -u)" != "0" ];


### PR DESCRIPTION
Currently, the cleanup causes the /tmp /var/log folders to be deleted. This causes an apt update in a pico container (or a container based on it) to fail.  

"Err:1 https://repo2.vanillaos.org sid InRelease
Couldn't create temporary file /tmp/apt.conf.zpjYhl for passing config to apt-key".
See https://github.com/hklemp/live-iso/actions/runs/6430942809/job/17462847099

"W: Could not open file '/var/log/apt/eipp.log.xz' - EIPP::OrderInstall (2: No such file or directory)
E: Directory '/var/log/apt/' missing"
see https://github.com/hklemp/live-iso/actions/runs/6431051053/job/17463173154#step:5:94 

This PR ensures that only the contents of the folders are deleted. 
