### PR TITLE
fix/ci: run vib-pr workflow under Docker too

### DIFF
--- a/.github/workflows/vib-pr.yml
+++ b/.github/workflows/vib-pr.yml
@@ -23,7 +23,7 @@ jobs:
         - uses: vanilla-os/vib-gh-action@v0.7.0
 
         - name: Build the Docker image
-          run: podman image build -f Containerfile --tag vanillaos/pico:validation .
+          run: docker image build -f Containerfile --tag vanillaos/pico:validation .
 
         - name: Upload vanilla-pico-rootfs
           uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Changes

This PR updates the `vib-pr.yml` workflow's image build to run under Docker too instead of Podman to have reproducibility with `vib-build.yml` which runs on commits to the main branch.