### PR TITLE
feat: multi-arch support for rootfs

### DIFF
--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -79,6 +79,8 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        buildkitd-flags: --allow-insecure-entitlement security.insecure
 
     - name: Login to GitHub Package Registry
       uses: docker/login-action@v3

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You need the [Vib](https://github.com/vanilla-os/Vib) tool to generate the Conta
 ```bash
 cd rootfs && sh build.sh && cd ..
 vib build recipe.yml
-podman image build -t vanillaos/pico .
+podman image build --cap-add CAP_MKNOD -t vanillaos/pico .
 ```
 
 ## Verify Image Build Provenance Attestation

--- a/recipe.yml
+++ b/recipe.yml
@@ -5,12 +5,36 @@ vibversion: 1.0.0
 stages:
 - id: build
   base: scratch
-  singlelayer: true
-  labels:
-    maintainer: Vanilla OS Contributors
   adds:
     - srcdst:
         rootfs/vanilla-pico.tar.zst: /
+
+  modules:
+  - name: debootstrap
+    type: shell
+    commands:
+      - /debootstrap/debootstrap --second-stage
+
+  - name: cleanup
+    type: shell
+    commands:
+      - rm -rf /usr/share/doc/*
+      - rm -rf /usr/share/info/*
+      - rm -rf /usr/share/lintian/overrides/*
+      - rm -rf /usr/share/locale/*
+      - rm -rf /usr/share/man/*
+      - rm -rf /var/cache
+      - rm -rf /var/log/*
+      - mkdir -p /var/cache/apt/archives/partial
+
+- id: dist
+  base: scratch
+  labels:
+    maintainer: Vanilla OS Contributors
+  copy:
+    - from: build
+      srcdst:
+        /: /
   cmd:
     exec:
-      - /bash
+      - /bin/bash

--- a/rootfs/build.sh
+++ b/rootfs/build.sh
@@ -12,6 +12,13 @@ CLEANUP_DIRS="/usr/share/doc/*
 /usr/share/locale/*
 /usr/share/man/*"
 
+# Target architecture
+ARCH_OPTION=""
+if [ -n "$ARCH" ]; then
+  ROOTFS_NAME=$ROOTFS_NAME-$ARCH
+  ARCH_OPTION=--arch=$ARCH
+fi
+
 # Root check - debootstrap requires root privileges
 if [ "$(id -u)" != "0" ];
   then echo "This script must be run as root"
@@ -33,7 +40,7 @@ fi
 mkdir -p $ROOTFS_NAME
 cp -r includes.rootfs/* $ROOTFS_NAME
 
-debootstrap \
+debootstrap $ARCH_OPTION \
     --variant=minbase \
     --include=$CUSTOM_PACKAGE,apt-utils,apt-transport-https,ca-certificates,gnupg2,bash,bzip2 \
     --keyring=includes.rootfs/usr/share/keyrings/vanilla_keyring.gpg \

--- a/rootfs/build.sh
+++ b/rootfs/build.sh
@@ -8,17 +8,9 @@ REPO_URL=http://repo2.vanillaos.org
 CUSTOM_PACKAGE=""
 CLEANUP_DIRS="/usr/share/doc/*
 /usr/share/info/*
-/usr/share/linda/*
 /usr/share/lintian/overrides/*
 /usr/share/locale/*
-/usr/share/man/*
-/usr/share/doc/kde/HTML/*/*
-/usr/share/gnome/help/*/*
-/usr/share/locale/*
-/usr/share/omf/*/*-*.emf
-/var/cache
-/var/log/*
-/tmp/*"
+/usr/share/man/*"
 
 # Root check - debootstrap requires root privileges
 if [ "$(id -u)" != "0" ];
@@ -45,6 +37,7 @@ debootstrap \
     --variant=minbase \
     --include=$CUSTOM_PACKAGE,apt-utils,apt-transport-https,ca-certificates,gnupg2,bash,bzip2 \
     --keyring=includes.rootfs/usr/share/keyrings/vanilla_keyring.gpg \
+    --foreign \
     sid \
     $ROOTFS_NAME \
     $REPO_URL
@@ -55,18 +48,9 @@ debootstrap \
 rm -rf $ROOTFS_NAME/etc/apt/sources.list
 
 # Cleanup
-chroot $ROOTFS_NAME apt update
-chroot $ROOTFS_NAME apt upgrade -y
-chroot $ROOTFS_NAME apt install -f -y
-chroot $ROOTFS_NAME apt clean
-chroot $ROOTFS_NAME apt autoremove -y
-
 for dir in $CLEANUP_DIRS; do
     rm -rf $ROOTFS_NAME/$dir
 done
-
-# Restore apt cache directory
-mkdir -p $ROOTFS_NAME/var/cache/apt/archives/partial
 
 # Compression
 tar -cvf $ROOTFS_NAME.tar -C $ROOTFS_NAME .

--- a/rootfs/includes.rootfs/etc/apt/sources.list.d/vanilla-base.sources
+++ b/rootfs/includes.rootfs/etc/apt/sources.list.d/vanilla-base.sources
@@ -1,6 +1,5 @@
 Types: deb
 URIs: http://repo2.vanillaos.org/
 Suites: sid
-Architectures: amd64
 Components: main contrib non-free non-free-firmware
 Signed-By: /usr/share/keyrings/vanilla_keyring.gpg


### PR DESCRIPTION
This PR introduces multi-architecture support for building the rootfs.

Related to https://github.com/Vanilla-OS/live-iso/issues/87.

### Changes:

+ The `debootstrap` process is now split into a two-stage workflow. The first stage uses the `--foreign` flag under the host architecture, while the second stage employs the `--second-stage` flag to finalize the process under the target architecture during container image build process.
+ Since `singlelayer` option is no longer used (https://github.com/Vanilla-OS/Vib/pull/119), the Vib recipe has been updated to a two-stage build process to reduce the final image size.

### Usage:

+ Build for host architecture: `sudo sh build.sh`
+ Build for AMD64: `sudo ARCH=amd64 sh build.sh`
+ Build for ARM64: `sudo ARCH=arm64 sh build.sh`
+ Build container image: `sudo podman build --cap-add CAP_MKNOD -t vanillaos/pico .` (since `debootstrap` requires `CAP_MKNOD` privilege)