### PR TITLE
feat/ci: native arm64 build

### DIFF
--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -14,16 +14,23 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
     permissions:
-      contents: write # Allow actions to create release
       packages: write # Allow pushing images to GHCR
       attestations: write # To create and write attestations
       id-token: write # Additional permissions for the persistence of the attestations
 
     steps:
     - uses: actions/checkout@v5
-    
+
     - name: Install debootstrap
       run: |
           sudo apt-get update
@@ -40,6 +47,12 @@ jobs:
       run: |
         sudo apt install -y podman
         sudo sh build.sh
+        cp vanilla-pico.tar.zst vanilla-pico-${{ matrix.arch }}.tar.zst
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: vanilla-pico-rootfs-${{ matrix.arch }}
+        path: rootfs/vanilla-pico-${{ matrix.arch }}.tar.zst
 
     - uses: vanilla-os/vib-gh-action@v1.0.6
 
@@ -47,6 +60,7 @@ jobs:
       with:
         name: Containerfile
         path: Containerfile
+        overwrite: true
 
     - name: Generate image name
       run: |
@@ -54,28 +68,11 @@ jobs:
         echo "REPO_OWNER_LOWERCASE=$REPO_OWNER_LOWERCASE" >> "$GITHUB_ENV"
         echo "IMAGE_URL=ghcr.io/$REPO_OWNER_LOWERCASE/pico" >> "$GITHUB_ENV"
 
-    - name: Extra image tag branch
-      if: ${{ github.ref_type != 'tag' }}
-      run: |
-        echo "EXTRA_TAG=ref,event=branch" >> "$GITHUB_ENV"
-
-    - name: Extra image tag release
-      if: ${{ github.ref_type == 'tag' }}
-      run: |
-        echo "EXTRA_TAG=raw,main" >> "$GITHUB_ENV"
-
     - name: Docker meta
-      id: docker_meta
+      id: meta
       uses: docker/metadata-action@v5
       with:
-        images: |
-          ${{ env. IMAGE_URL }}
-        tags: |
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{raw}}
-          type=semver,pattern=v{{major}}
-          type=${{ env.EXTRA_TAG }}
+        images: ${{ env.IMAGE_URL }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -88,41 +85,120 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and Push the Docker image
-      id: push
+    - name: Build and push by digest
+      id: build
       uses: docker/build-push-action@v6
       with:
         context: .
         file: Containerfile
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.docker_meta.outputs.tags }}
-        labels: ${{ steps.docker_meta.outputs.labels }}
+        tags: ${{ env.IMAGE_URL }}
+        labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        platforms: linux/amd64
+        platforms: linux/${{ matrix.arch }}
         provenance: false
-    
+        outputs: type=image,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+
     - name: Attest pushed image
       uses: actions/attest-build-provenance@v3
       id: attest
       if: ${{ github.event_name != 'pull_request' }}
       with:
         subject-name: ${{ env.IMAGE_URL }}
-        subject-digest: ${{ steps.push.outputs.digest }}
+        subject-digest: ${{ steps.build.outputs.digest }}
         push-to-registry: false
+
+    - name: Export digest
+      if: ${{ github.event_name != 'pull_request' }}
+      run: |
+        mkdir -p ${{ runner.temp }}/digests
+        digest="${{ steps.build.outputs.digest }}"
+        touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+    - name: Upload digest
+      uses: actions/upload-artifact@v4
+      if: ${{ github.event_name != 'pull_request' }}
+      with:
+        name: digests-${{ matrix.arch }}
+        path: ${{ runner.temp }}/digests/*
+        if-no-files-found: error
+        retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: build
+    permissions:
+      contents: write # Allow actions to create release
+      packages: write # Allow pushing images to GHCR
+
+    steps:
+    - name: Generate image name
+      run: |
+        REPO_OWNER_LOWERCASE="$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')"
+        echo "REPO_OWNER_LOWERCASE=$REPO_OWNER_LOWERCASE" >> "$GITHUB_ENV"
+        echo "IMAGE_URL=ghcr.io/$REPO_OWNER_LOWERCASE/pico" >> "$GITHUB_ENV"
+
+    - name: Download digests
+      uses: actions/download-artifact@v4
+      with:
+        path: ${{ runner.temp }}/digests
+        pattern: digests-*
+        merge-multiple: true
+
+    - name: Extra image tag branch
+      if: ${{ github.ref_type != 'tag' }}
+      run: |
+        echo "EXTRA_TAG=ref,event=branch" >> "$GITHUB_ENV"
+
+    - name: Extra image tag release
+      if: ${{ github.ref_type == 'tag' }}
+      run: |
+        echo "EXTRA_TAG=raw,main" >> "$GITHUB_ENV"
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.IMAGE_URL }}
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{raw}}
+          type=semver,pattern=v{{major}}
+          type=${{ env.EXTRA_TAG }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Package Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create manifest list and push
+      working-directory: ${{ runner.temp }}/digests
+      run: |
+        docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ env.IMAGE_URL }}@sha256:%s ' *)
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: Containerfile
+
+    - uses: actions/download-artifact@v4
+      with:
+        path: rootfs
+        pattern: vanilla-pico-rootfs-*
+        merge-multiple: true
 
     - name: Create Checksum
       working-directory: rootfs
-      run: |
-        sha256sum vanilla-pico.tar.gz > checksum.txt
-
-    - uses: actions/upload-artifact@v4
-      with:
-        name: vanilla-pico-rootfs
-        path: rootfs/vanilla-pico.tar.zst
+      run: sha256sum vanilla-pico-*.tar.zst > checksum.txt
 
     - uses: softprops/action-gh-release@v2
-      if:  ${{ github.event_name != 'pull_request' }}
       with:
         token: "${{ secrets.GITHUB_TOKEN }}"
         tag_name: "continuous"
@@ -130,13 +206,13 @@ jobs:
         name: "Continuous Build"
         files: |
           Containerfile
-          rootfs/vanilla-pico.tar.gz
+          rootfs/vanilla-pico-*.tar.zst
           rootfs/checksum.txt
 
   differ:
     runs-on: ubuntu-latest
-    if:  github.ref_type == 'tag' && github.repository == 'vanilla-os/pico-image'
-    needs: build
+    if: github.ref_type == 'tag' && github.repository == 'vanilla-os/pico-image'
+    needs: merge
     container:
       image: ghcr.io/vanilla-os/pico:main
 


### PR DESCRIPTION
This PR introduces native ARM64 support for building `pico-image` in GitHub Actions. It leverages Docker's `buildx imagetools create` to create a multi-arch manifest list. Ref: https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners.

Related to https://github.com/Vanilla-OS/live-iso/issues/87.

### Requirements:
1. https://github.com/Vanilla-OS/vib-gh-action/pull/6 be merged.
2. ARM64 packages be available in https://repo2.vanillaos.org, or use the official Debian sid repo as an alternative.